### PR TITLE
Enable or disable the plugin button on message selection.

### DIFF
--- a/skins/classic/tb_label.css
+++ b/skins/classic/tb_label.css
@@ -6,12 +6,13 @@
 * CSS is Based on a patch for roundcube 0.3 I found a long time ago
 */
 
+#messagetoolbar #tb_label_popuplink,
 #tb_label_popuplink {
   background-image: url(thunderbird_32.png);
   background-repeat: no-repeat;
   width: 32px;
   height: 32px;
-  padding: 0px;
+  padding: 0px !important;
   margin: 0px 5px 0px 5px;
 }
 

--- a/tb_label.js
+++ b/tb_label.js
@@ -386,7 +386,15 @@ $(document).ready(function() {
 		rcmail.add_element(button, 'toolbar');
 		rcmail.register_button('plugin.thunderbird_labels.rcm_tb_label_submenu', 'tb_label_popuplink', 'link');
 		*/
-		rcmail.register_command('plugin.thunderbird_labels.rcm_tb_label_submenu', rcm_tb_label_submenu, true);
+		//rcmail.register_command('plugin.thunderbird_labels.rcm_tb_label_submenu', rcm_tb_label_submenu, true);
+		rcmail.register_command('plugin.thunderbird_labels.rcm_tb_label_submenu', rcm_tb_label_submenu, rcmail.env.uid);
+
+		// add event-listener to message list		
+		if (rcmail.message_list) {
+		    rcmail.message_list.addEventListener('select', function(list){
+			    rcmail.enable_command('plugin.thunderbird_labels.rcm_tb_label_submenu', list.get_selection().length > 0);
+			});
+		}
 	});
 	
 	// -- add my submenu to roundcubes UI (for roundcube classic only?)

--- a/thunderbird_labels.php
+++ b/thunderbird_labels.php
@@ -62,7 +62,8 @@ class thunderbird_labels extends rcube_plugin
 					'domain' => $this->ID,
 					'type' => 'link',
 					'content' => ($this->rc->config->get('skin') == 'larry') ? $this->gettext('tb_label_button_label') : ' ', 
-					'class' => ($this->rc->config->get('skin') == 'larry') ? 'button' : 'tb_noclass',
+					'class' => (($this->rc->config->get('skin') == 'larry') ? 'button' : 'tb_noclass').' buttonPas disabled',
+					'classact' => (($this->rc->config->get('skin') == 'larry') ? 'button' : 'tb_noclass'),
 					),
 				'toolbar'
 			);


### PR DESCRIPTION
Disable button when there is no message selected and enable it again when the user selects a message. (this is the default behaviour with messagetoolbar buttons).