### PR TITLE
Clean code (remove unnecessary skin check).

### DIFF
--- a/skins/classic/tb_label.css
+++ b/skins/classic/tb_label.css
@@ -14,6 +14,7 @@
   height: 32px;
   padding: 0px !important;
   margin: 0px 5px 0px 5px;
+  text-indent: -5000px;
 }
 
 #tb_label_popup

--- a/thunderbird_labels.php
+++ b/thunderbird_labels.php
@@ -61,9 +61,9 @@ class thunderbird_labels extends rcube_plugin
 					'title' => 'tb_label_button_title',
 					'domain' => $this->ID,
 					'type' => 'link',
-					'content' => ($this->rc->config->get('skin') == 'larry') ? $this->gettext('tb_label_button_label') : ' ', 
-					'class' => (($this->rc->config->get('skin') == 'larry') ? 'button' : 'tb_noclass').' buttonPas disabled',
-					'classact' => (($this->rc->config->get('skin') == 'larry') ? 'button' : 'tb_noclass'),
+					'content' => $this->gettext('tb_label_button_label'), 
+					'class' => 'button buttonPas disabled',
+					'classact' => 'button',
 					),
 				'toolbar'
 			);


### PR DESCRIPTION
In my last pull request, i tried to change the minimum code as possible.
Meanwhile, I had to create a new `larry` based skin; when testing it, the plugin didn't show the icon properly.
I removed the unnecessary skin check. After all, CSS class `tb_noclass` is not even defined and using `text-indent: -5000px` in the `classic` skin is the consistent skin way of doing it.